### PR TITLE
Add GameJolt CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ env:
   global:
   - GAME_NAME="overwhelming-odors"
   - ITCH_IO_USER="flesk"
+  - GAMEJOLT_GAME_ID=334334
+  - GAMEJOLT_PACKAGE=351065
 
 install:
 - docker pull gamedrivendesign/godot-export
 - wget -q https://dl.itch.ovh/butler/linux-amd64/head/butler && chmod +x butler
+- wget -q -O gjpush.zip https://github.com/gamejolt/cli/releases/download/v0.1.0/linux.zip && unzip gjpush.zip && chmod +x gjpush
 
 # Each of the following lines exports the game for a given platform.
 # You can specify the platform in the EXPORT_NAME variable
@@ -38,9 +41,9 @@ before_deploy:
 - cp -R output/mac/* .
 
 deploy:
-# The following block is responsible to upload the zip files
-# created above to GitHub Releases whenever a new git tag
-# is created.
+# The following blocks are responsible for uploading the zip files
+# created above to GitHub Releases, Itch.io and GameJolt.com
+# whenever a new git tag is created.
 - provider: releases
   skip-cleanup: true
   api_key: $GITHUB_TOKEN
@@ -58,4 +61,11 @@ deploy:
   script: ./itch-upload.sh
   skip-cleanup: true
   on:
-    branch: master
+    all_branches: true
+    tags: true
+- provider: script
+  script: ./gamejolt-upload.sh
+  skip-cleanup: true
+  on:
+    all_branches: true
+    tags: true

--- a/gamejolt-upload.sh
+++ b/gamejolt-upload.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# Note: Since GameJolt release tags use semver, replace $TRAVIS_TAG with a valid version if not built from a Git tag.
+
+./gjpush -t $GAMEJOLT_API_TOKEN -g $GAMEJOLT_GAME_ID -p $GAMEJOLT_PACKAGE -r $TRAVIS_TAG -b "${GAME_NAME}-html5.zip"
+./gjpush -t $GAMEJOLT_API_TOKEN -g $GAMEJOLT_GAME_ID -p $GAMEJOLT_PACKAGE -r $TRAVIS_TAG "${GAME_NAME}-linux.zip"
+./gjpush -t $GAMEJOLT_API_TOKEN -g $GAMEJOLT_GAME_ID -p $GAMEJOLT_PACKAGE -r $TRAVIS_TAG "${GAME_NAME}-mac.zip"
+./gjpush -t $GAMEJOLT_API_TOKEN -g $GAMEJOLT_GAME_ID -p $GAMEJOLT_PACKAGE -r $TRAVIS_TAG "${GAME_NAME}-windows.zip"


### PR DESCRIPTION
Adds continuous integration+deployment to GameJolt, using the experimental GameJolt CLI: https://github.com/gamejolt/cli.

GameJolt uploads need a semantic version, so I've set all providers to release only on tags (on any branch), since that will be most consistent.